### PR TITLE
adjust parsing of peers for differing data structures from xml output

### DIFF
--- a/zeroconf/actions.py
+++ b/zeroconf/actions.py
@@ -64,7 +64,12 @@ def connected_peers():
     if not (result['cliOutput'] and result['cliOutput']['peerStatus']):
         return peers
 
-    for peer in result['cliOutput']['peerStatus']['peer']:
+    if isinstance(result['cliOutput']['peerStatus']['peer'], (list,)):
+        xmlPeers = result['cliOutput']['peerStatus']['peer']
+    else:
+        xmlPeers = result['cliOutput']['peerStatus'].values()
+
+    for peer in xmlPeers:
         hostname = peer['hostname']
         if hostname != 'localhost':
             peers.append(hostname)


### PR DESCRIPTION
The previous fix for the data type traceback fixed the problem for multiple peers returned in the XML output, but it introduced the traceback for a single peer. This patch checks the data type for the 'peers' value and adjust the parsing of the hostnames according to whether the 'peer' output is a dictionary or a list of dictionaries.