### PR TITLE
Limit the discovery to one or more interfaces

### DIFF
--- a/zeroconf/actions.py
+++ b/zeroconf/actions.py
@@ -23,10 +23,13 @@ def _on_service_state_change(zeroconf, service_type, name, state_change):
             glusterd_hosts.append(socket.inet_ntoa(info.address))
 
 
-def discover_hosts(timeout=5):
+def discover_hosts(timeout=5, interfaces=None):
     """ Find hosts that announce themselves with _glusterd._tcp.local.
     """
-    zeroconf = Zeroconf()
+    if interfaces:
+        zeroconf = Zeroconf(interfaces=interfaces)
+    else:
+        zeroconf = Zeroconf()
     browser = ServiceBrowser(zeroconf, '_glusterd._tcp.local.',
                              handlers=[_on_service_state_change])
 

--- a/zeroconf/cli.py
+++ b/zeroconf/cli.py
@@ -10,10 +10,8 @@ def check_ipv4_address(ips):
     IPv4 addresses
     """
     ipv4 = re.compile("^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
-    for ip in ips:
-        if not ipv4.match(ip):
-            return False
-        return True
+    tmp = [ipv4.match(x) for x in ips]
+    return all(tmp)
 
 
 def main():

--- a/zeroconf/cli.py
+++ b/zeroconf/cli.py
@@ -1,11 +1,27 @@
 import argparse
+import re
 import os
 
 from .actions import discover_hosts, connected_peers, peer_probe
 
+
+def check_ipv4_address(ips):
+    """Checks whether a list of IP contains valid
+    IPv4 addresses
+    """
+    ipv4 = re.compile("^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
+    for ip in ips:
+        if not ipv4.match(ip):
+            return False
+        return True
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-t', '--timeout', help='seconds to wait for replies', type=int, default=5)
+    parser.add_argument('-i', '--interfaces', help='limits the discovery on some\
+                        interfaces (it accepts for now only IPv4 addresses\
+                        separated by space)', nargs='*', default=None)
     parser.add_argument('-v', '--verbose', help='increase output verbosity', action='count')
     parser.add_argument('action', help='command to execute', choices=['discover', 'probe'], default='discover', nargs='?')
 
@@ -14,7 +30,11 @@ def main():
     except:
         return os.EX_USAGE
 
-    hosts = discover_hosts(args.timeout)
+    if not check_ipv4_address(args.interfaces):
+        print("IP address not valid")
+        return os.EX_USAGE
+
+    hosts = discover_hosts(timeout=args.timeout, interfaces=args.interfaces)
     for host in hosts:
         print('discovered host: %s' % (host))
 

--- a/zeroconf/cli.py
+++ b/zeroconf/cli.py
@@ -30,9 +30,10 @@ def main():
     except:
         return os.EX_USAGE
 
-    if not check_ipv4_address(args.interfaces):
-        print("IP address not valid")
-        return os.EX_USAGE
+    if args.interfaces:
+        if not check_ipv4_address(args.interfaces):
+            print("IP address not valid")
+            return os.EX_USAGE
 
     hosts = discover_hosts(timeout=args.timeout, interfaces=args.interfaces)
     for host in hosts:


### PR DESCRIPTION
With this we can limit the discovery on just some interfaces.
If nothing will be passed then all the local interfaces will be used.